### PR TITLE
Added gentoo installation instructions and ebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ You can install Nuntius from:
 
  * Fedora: yum install nuntius
  * [Arch Linux (AUR)](https://aur.archlinux.org/packages/nuntius/)
+ * Gentoo installation instructions
+   * Copy the ebuild located in `gentoo/gnome-extra/nuntius-9999.ebuild` to your local repository (`/usr/local/portage`)
+   * Build the manifest (`ebuild nuntius-9999.ebuild digest`)
+   * Add `gnome-extra/nuntius ~amd64` or `gnome-extra/nuntius ~x86` to your `package.accept_keywords`
+   * Merge nuntius to your system (`emerge nuntius`)
 
 You will need to install Nuntius also on your phone or tablet.
 

--- a/gentoo/gnome-extra/nuntius/nuntius-9999.ebuild
+++ b/gentoo/gnome-extra/nuntius/nuntius-9999.ebuild
@@ -1,0 +1,35 @@
+# Copyright 2015 Fin Christensen
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+EGIT_REPO_URI="https://github.com/holylobster/nuntius-linux.git"
+VALA_MIN_API_VERSION="0.18"
+
+inherit eutils git-r3 vala
+
+DESCRIPTION="Nuntius delivers notifications from your phone or tablet to your computer"
+HOMEPAGE="https://github.com/holylobster/nuntius-linux"
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+RDEPEND="
+	>=x11-libs/gtk+-3.14
+	>=dev-libs/glib-2.38
+	>=dev-libs/json-glib-0.16.2
+	>=media-gfx/qrencode-3.1.0"
+DEPEND="${RDEPEND}
+	>=dev-vcs/git-2.4.6
+	>=dev-util/intltool-0.50
+	$(vala_depend)"
+
+src_unpack() {
+	git-r3_src_unpack
+}
+
+src_prepare() {
+	./autogen.sh || die "Autogen failed!"
+	vala_src_prepare
+}


### PR DESCRIPTION
This contains only a 'install from git' version. The releases are not included.
