### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Nuntius
 ===================================
 
-##Introduction
+## Introduction
 Nuntius delivers notifications from your phone or tablet to your computer over Bluetooth.
 
 Nuntius is an Open Source project from HolyLobster.
@@ -11,12 +11,12 @@ You will also need to restart your session to auto-start nuntius.
 
 For more information on the project and the companion tools to install on the computer check https://github.com/holylobster
 
-##The Icon
+## The Icon
 You may have questions on the icon. Nice shot.
 In fact most of the Nuntius development time has been spent on the icon design concept.
 If you have suggestions on how to improve it we are very open... but... we think it is hardly possible to do better than this.
 
-##Packages
+## Packages
 You can install Nuntius from:
 
  * Fedora: `dnf install nuntius` (use `yum` instead of `dnf` on Fedora <= 21)
@@ -28,11 +28,11 @@ At the moment Nuntius is available for Android, check here
 
  * https://github.com/holylobster/nuntius-android
 
-##Getting in touch
+## Getting in touch
 We have an IRC channel: #nuntius on the irc.gnome.org server.
 Feel free to join and talk to us! Note that the channel is new and there are not many people (yet!) so be patient and hang around if you do not receive a reply immediately.
 
-##Some tips to debug
+## Some tips to debug
  * Launch the bluetooth dameon as "sudo  /usr/libexec/bluetooth/bluetoothd -d -n"
  * Using bluetoothctl
    * I had to set "agent on", "default-agent" and "trust 98:D6:F7:73:03:F1"


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
