### PR TITLE
vala 0.42.0 does not allow to set a default with a custom get accessor

### DIFF
--- a/src/notification.vala
+++ b/src/notification.vala
@@ -35,7 +35,7 @@ public class Notification : Object {
     public bool read {
         get {
             if (_read != null) {
-            return _read;
+                return _read;
             }
             return false; // default value
         }

--- a/src/notification.vala
+++ b/src/notification.vala
@@ -33,14 +33,18 @@ public class Notification : Object {
 
     [CCode (notify = false)]
     public bool read {
-        get { return _read; }
+        get {
+            if (_read != null) {
+            return _read;
+            }
+            return false; // default value
+        }
         set {
             if (_read != value) {
                 _read = value;
                 notify_property("read");
             }
         }
-        default = false;
     }
 
     public Notification(Connection connection, string id, string package_name, string app_name, string title, string? flag, string? key, string? body, BytesIcon? icon, string[]? actions) {


### PR DESCRIPTION
Hi,

When building with vala 0.42.0, we get the following error (resulting in a build failure):
```
src/notification.vala:35.5-35.20: error: Property `Nuntius.Notification.read' with custom `get' accessor and/or `set' mutator cannot have `default' value
    public bool read {
    ^^^^^^^^^^^^^^^^
```
The change in the vala compiler behavior is brought with commit https://github.com/GNOME/vala/commit/0d396f7daaf34596b159380b8ee2a57799ac9336

This change fixes the issue.

Debian bug reference: https://bugs.debian.org/907936

Joseph