### PR TITLE
Posix.SIG* have been deprecated since vala 0.40, use Posix.Signal.*

### DIFF
--- a/src/main.vala
+++ b/src/main.vala
@@ -29,9 +29,9 @@ public static int main(string[] args) {
 
     app = new Nuntius.Application();
 
-    Unix.signal_add(Posix.SIGINT, on_terminate_app);
-    Unix.signal_add(Posix.SIGHUP, on_terminate_app);
-    Unix.signal_add(Posix.SIGTERM, on_terminate_app);
+    Unix.signal_add(Posix.Signal.INT, on_terminate_app);
+    Unix.signal_add(Posix.Signal.HUP, on_terminate_app);
+    Unix.signal_add(Posix.Signal.TERM, on_terminate_app);
 
     return app.run(args);
 }


### PR DESCRIPTION
Hi,

This PR fixes the following warnings we get when compiling with vala >= 0.40.0:
```
src/main.vala:32.21-32.32: warning: Posix.SIGINT has been deprecated since vala-0.40. Use Posix.Signal.INT
src/main.vala:33.21-33.32: warning: Posix.SIGHUP has been deprecated since vala-0.40. Use Posix.Signal.HUP
src/main.vala:34.21-34.33: warning: Posix.SIGTERM has been deprecated since vala-0.40. Use Posix.Signal.TERM
```

Joseph