### PR TITLE
Update appdatafile to match a more current format

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@ autostartdir = $(sysconfdir)/xdg/autostart
 autostart_DATA = $(desktop_DATA)
 
 # appdata file
-appdatadir = $(datadir)/appdata
+appdatadir = $(datadir)/metainfo
 appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 appdata_in_files = data/org.holylobster.nuntius.appdata.xml.in
 @INTLTOOL_XML_RULE@

--- a/data/org.holylobster.nuntius.appdata.xml.in
+++ b/data/org.holylobster.nuntius.appdata.xml.in
@@ -8,14 +8,14 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0-or-later</project_license>
   <description>
-    <p>
+    <_p>
       Nuntius delivers notifications from your phone or tablet to your computer
       over Bluetooth.
-    </p>
-    <p>
+    </_p>
+    <_p>
       To use Nuntius you will need to install a companion tool on your phone or
       tablet and pair it via Bluetooth.
-    </p>
+    </_p>
   </description>
   <screenshots>
       <screenshot type="default">

--- a/data/org.holylobster.nuntius.appdata.xml.in
+++ b/data/org.holylobster.nuntius.appdata.xml.in
@@ -3,8 +3,8 @@
 <component type="desktop-application">
   <id>org.holylobster.nuntius.desktop</id>
   <launchable type="desktop-id">org.holylobster.nuntius.desktop</launchable>
-  <name>Nuntius</name>
-  <summary>Nuntius delivers notifications from your phone or tablet to your computer</summary>
+  <_name>Nuntius</_name>
+  <_summary>Nuntius delivers notifications from your phone or tablet to your computer</_summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0-or-later</project_license>
   <description>
@@ -19,7 +19,7 @@
   </description>
   <screenshots>
       <screenshot type="default">
-          <caption>Nuntius play store feature</caption>
+          <_caption>Nuntius play store feature</_caption>
           <image type="source" width="1024" height="500">https://raw.githubusercontent.com/holylobster/nuntius-android/master/store-stuff/play-store-feature.jpg</image>
       </screenshot>
   </screenshots>

--- a/data/org.holylobster.nuntius.appdata.xml.in
+++ b/data/org.holylobster.nuntius.appdata.xml.in
@@ -1,22 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2015 Ignacio Casal Quinteiro <icq@gnome.org> -->
-<application>
-  <id type="desktop">org.holylobster.nuntius.desktop</id>
-  <metadata_license>CC0</metadata_license>
-  <project_license>GPL-2.0+</project_license>
+<component type="desktop-application">
+  <id>org.holylobster.nuntius.desktop</id>
+  <launchable type="desktop-id">org.holylobster.nuntius.desktop</launchable>
+  <name>Nuntius</name>
+  <summary>Nuntius delivers notifications from your phone or tablet to your computer</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-or-later</project_license>
   <description>
-    <_p>
+    <p>
       Nuntius delivers notifications from your phone or tablet to your computer
       over Bluetooth.
-    </_p>
-    <_p>
+    </p>
+    <p>
       To use Nuntius you will need to install a companion tool on your phone or
       tablet and pair it via Bluetooth.
-    </_p>
+    </p>
   </description>
   <screenshots>
-    <screenshot type="default">https://raw.githubusercontent.com/holylobster/nuntius-android/master/store-stuff/play-store-feature.jpg</screenshot>
+      <screenshot type="default">
+          <caption>Nuntius play store feature</caption>
+          <image type="source" width="1024" height="500">https://raw.githubusercontent.com/holylobster/nuntius-android/master/store-stuff/play-store-feature.jpg</image>
+      </screenshot>
   </screenshots>
   <url type="homepage">https://github.com/orgs/holylobster</url>
-  <updatecontact>icq@gnome.org</updatecontact>
-</application>
+  <update_contact>icq@gnome.org</update_contact>
+</component>


### PR DESCRIPTION
Hi,

This PR updates your appdata file to match a more current format. Formatting rules for appdata files can be found here: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html
That document also points out that appdata files should be placed in `/usr/share/metainfo` now and that support for using `/usr/share/appdata` might be dropped in the future.

You can validate your file using:
```
appstreamcli validate --pedantic data/org.holylobster.nuntius.appdata.xml.in
```

Thanks for your time,
Joseph